### PR TITLE
Fix glog/gflags vars related to find scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,10 +28,10 @@ ExternalProject_Add(ceres_src
   UPDATE_COMMAND ""
   CONFIGURE_COMMAND cmake
     -DGFLAGS=ON
-    -DGFLAGS_LIBRARY=${gflags_catkin_LIBRARIES}
-    -DGFLAGS_INCLUDE_DIR=${gflags_catkin_INCLUDE_DIRS}
-    -DGLOG_INCLUDE_DIR=${glog_catkin_INCLUDE_DIRS}
-    -DGLOG_LIBRARY=${glog_catkin_LIBRARIES}
+    -DGFLAGS_LIBRARY_DIR_HINTS=${gflags_catkin_LIBRARIES}
+    -DGFLAGS_INCLUDE_DIR_HINTS=${gflags_catkin_INCLUDE_DIR}
+    -DGLOG_INCLUDE_DIR_HINTS=${glog_catkin_INCLUDE_DIR}
+    -DGLOG_LIBRARY_DIR_HINTS=${glog_catkin_LIBRARIES}
     -DBUILD_DOCUMENTATION=OFF
     -DSUITESPARSE_INCLUDE_DIR_HINTS=${suitesparse_PREFIX}/include/suitesparse
     -DSUITESPARSE_LIBRARY_DIR_HINTS=${suitesparse_PREFIX}/lib


### PR DESCRIPTION
We encountered an error when building ceres_catkin on a machine that had glog/gflags installed as a system dependency as well. ceres_catkin would link against that version. Some debugging later we found that these hint-variables for the find scripts have actually been wrong all along, but it still seems to work for most people. Here are the proper variables that fixed it on that particular machine.

[Link to the glog find script doc](https://ceres-solver.googlesource.com/ceres-solver/+/refs/tags/1.12.0/cmake/FindGlog.cmake#57)
[Link to the gflag find script doc](https://ceres-solver.googlesource.com/ceres-solver/+/refs/tags/1.12.0/cmake/FindGflags.cmake#69)